### PR TITLE
feat: add hyperlink for missing instructors

### DIFF
--- a/content.js
+++ b/content.js
@@ -150,9 +150,11 @@ async function main(teachers) {
                 const { id, rating, count } = teacherInfo[name];
 
                 if (!id) {
-                    console.warn(`No RUPP ID found for teacher: ${name}`);
+                    console.info(`No RUPP ID found for teacher: ${name}`);
                     const noIdSpan = document.createElement('span');
-                    noIdSpan.innerHTML = `No entry for ${name}`;
+                    noIdSpan.innerHTML = `${name} not found in RUPP.
+                        <br><a href="https://rupp.onrender.com/add" target="_blank">Request to have them added</a>
+                    `;
                     return noIdSpan;
                 }
 


### PR DESCRIPTION
# Description
Changes the content of the RUPP column for missing instructors to the following:

<img width="1308" height="191" alt="image" src="https://github.com/user-attachments/assets/d8e0eea3-a215-4d7e-a1ce-18bd17a2b748" />

# Testing
1. Go to the CRS Preenlistment or Student Registration modules
2. Search for classes with missing RUPP instructors. GEs usually have a few.
3. Assert that the RUPP Rating column shows `X not found in RUPP. Request to have them added`.
4. Assert that clicking the hyperlink leads to https://rupp.onrender.com/add
